### PR TITLE
Fix the skip bug and unwanted output of now command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ config.json
 __pycache__
 *.py[cod]
 *$py.class
+
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/music.py
+++ b/music.py
@@ -161,7 +161,7 @@ class Music(commands.Cog):
             ctx.voice_state.autoplay = False
             await ctx.message.add_reaction('⏭')
             await ctx.message.add_reaction('🎶')
-            ctx.voice_state.voice.stop()
+            ctx.voice_state.skip()
         
         else:
             await ctx.message.add_reaction('⏭')

--- a/music.py
+++ b/music.py
@@ -103,8 +103,14 @@ class Music(commands.Cog):
     @commands.command(name='now', aliases=['current', 'playing', 'np', 'nowplaying'])
     async def _now(self, ctx: commands.Context):
         """Displays the currently playing song."""
-        embed = ctx.voice_state.current.create_embed()
-        await ctx.send(embed=embed)
+        if ctx.voice_state.is_playing:
+            embed = ctx.voice_state.current.create_embed()
+            await ctx.send(embed=embed)
+        else:
+            messge = await ctx.send('Check if you even playing something!!!! LOL')
+            await messge.add_reaction('🤣')
+            await messge.add_reaction('🤦‍♂️')
+            return messge            
 
     @commands.command(name='pause', aliases=['pa'])
     @commands.has_permissions(manage_guild=True)
@@ -149,13 +155,21 @@ class Music(commands.Cog):
             await messge.add_reaction('🤣')
             await messge.add_reaction('🤦‍♂️')
             return messge
-
-        voter = ctx.message.author
-        if voter == ctx.voice_state.current.requester or voter.id not in ctx.voice_state.skip_votes:
+        
+        if len(ctx.voice_state.songs)==0:
+            ctx.voice_state.songs.clear()
+            ctx.voice_state.autoplay = False
+            messge = await ctx.send(len(ctx.voice_state.songs))
+            await ctx.message.add_reaction('⏭')
+            await ctx.message.add_reaction('🎶')
+            ctx.voice_state.voice.stop()
+        
+        else:
+            messge = await ctx.send(len(ctx.voice_state.songs))
             await ctx.message.add_reaction('⏭')
             await ctx.message.add_reaction('🎶')
             ctx.voice_state.skip()
-
+            
         # elif voter.id not in ctx.voice_state.skip_votes:
         #     ctx.voice_state.skip_votes.add(voter.id)
         #     total_votes = len(ctx.voice_state.skip_votes)

--- a/music.py
+++ b/music.py
@@ -159,13 +159,11 @@ class Music(commands.Cog):
         if len(ctx.voice_state.songs)==0:
             ctx.voice_state.songs.clear()
             ctx.voice_state.autoplay = False
-            messge = await ctx.send(len(ctx.voice_state.songs))
             await ctx.message.add_reaction('⏭')
             await ctx.message.add_reaction('🎶')
             ctx.voice_state.voice.stop()
         
         else:
-            messge = await ctx.send(len(ctx.voice_state.songs))
             await ctx.message.add_reaction('⏭')
             await ctx.message.add_reaction('🎶')
             ctx.voice_state.skip()


### PR DESCRIPTION
## Description
The bot had 2 major bugs, first one was if we skipped a single song and tried to play another song after that, due to issues with autoplay feature the song won't play at all. The second bug in question is the now command displaying error code when no song is playing.

Bug 1: Expected result, new song should play after a single song is skipped.
Bug 2: Expected result, some abstract message should be displayed so the user is not exposed to the internals of the python based discord bot.

This PR fixes both of these bugs have a look.